### PR TITLE
Update credit_card_widget.dart

### DIFF
--- a/lib/credit_card_widget.dart
+++ b/lib/credit_card_widget.dart
@@ -143,7 +143,7 @@ class _CreditCardWidgetState extends State<CreditCardWidget>
     BuildContext context,
     Orientation orientation,
   ) {
-    final TextStyle defaultTextStyle = Theme.of(context).textTheme.title.merge(
+    final TextStyle defaultTextStyle = Theme.of(context).textTheme.subtitle1.merge(
           TextStyle(
             color: Colors.black,
             fontFamily: 'halter',
@@ -264,7 +264,7 @@ class _CreditCardWidgetState extends State<CreditCardWidget>
     BuildContext context,
     Orientation orientation,
   ) {
-    final TextStyle defaultTextStyle = Theme.of(context).textTheme.title.merge(
+    final TextStyle defaultTextStyle = Theme.of(context).textTheme.subtitle1.merge(
           TextStyle(
             color: Colors.white,
             fontFamily: 'halter',


### PR DESCRIPTION
The Flutter Material design text theme class no longer supports the title property and hence the credit_card_widget fails when flutter does a build.
Hence a change to utilise the subtitle1 property in place of the now deprecated title property.